### PR TITLE
Mirror of bitcoin bitcoin#18038

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1272,6 +1272,9 @@ bool AppInitMain(NodeContext& node)
     CScheduler::Function serviceLoop = std::bind(&CScheduler::serviceQueue, &scheduler);
     threadGroup.create_thread(std::bind(&TraceThread<CScheduler::Function>, "scheduler", serviceLoop));
 
+    assert(!node.scheduler);
+    node.scheduler = &scheduler;
+
     // Gather some entropy once per minute.
     scheduler.scheduleEvery([]{
         RandAddPeriodic();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -48,6 +48,9 @@ static_assert(MINIUPNPC_API_VERSION >= 10, "miniUPnPc API version >= 10 assumed"
 // Dump addresses to peers.dat every 15 minutes (900s)
 static constexpr int DUMP_PEERS_INTERVAL = 15 * 60;
 
+// Attempt initial broadcast of locally submitted txns every 10 minutes.
+static constexpr std::chrono::milliseconds REATTEMPT_BROADCAST_INTERVAL = std::chrono::milliseconds(10 * 60);
+
 /** Number of DNS seeds to query when the number of connections is low. */
 static constexpr int DNSSEEDS_TO_QUERY_AT_ONCE = 3;
 
@@ -1631,16 +1634,13 @@ void CConnman::ThreadDNSAddressSeed()
     LogPrintf("%d addresses found from DNS seeds\n", found);
 }
 
-
-
-
-
-
-
-
-
-
-
+void CConnman::AttemptInitialBroadcast()
+{
+    ForEachNode([this](CNode* pnode)
+    {
+        this->m_msgproc->QueueUnbroadcastTxs(pnode);
+    });
+}
 
 void CConnman::DumpAddresses()
 {
@@ -2331,6 +2331,9 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
 
     // Dump network addresses
     scheduler.scheduleEvery(std::bind(&CConnman::DumpAddresses, this), DUMP_PEERS_INTERVAL * 1000);
+
+    // Attempt to broadcast transactions that have not yet been acknowledged by the network
+    scheduler.scheduleEvery(std::bind(&CConnman::AttemptInitialBroadcast, this), REATTEMPT_BROADCAST_INTERVAL.count() );
 
     return true;
 }

--- a/src/net.h
+++ b/src/net.h
@@ -377,6 +377,7 @@ private:
     NodeId GetNewNodeId();
 
     size_t SocketSendData(CNode *pnode) const;
+    void AttemptInitialBroadcast();
     void DumpAddresses();
 
     // Network stats
@@ -514,6 +515,7 @@ public:
     virtual bool SendMessages(CNode* pnode) = 0;
     virtual void InitializeNode(CNode* pnode) = 0;
     virtual void FinalizeNode(NodeId id, bool& update_connection_time) = 0;
+    virtual void QueueUnbroadcastTxs(CNode* pnode) = 0;
 
 protected:
     /**

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1562,6 +1562,11 @@ void static ProcessGetData(CNode* pfrom, const CChainParams& chainparams, CConnm
             if (mi != mapRelay.end()) {
                 connman->PushMessage(pfrom, msgMaker.Make(nSendFlags, NetMsgType::TX, *mi->second));
                 push = true;
+                // Once a peer requests GETDATA for a txn, we deem initial broadcast a success
+                int num = mempool.m_unbroadcast_txids.erase(inv.hash);
+                if (num) {
+                    LogPrint(BCLog::NET, "Removed %i from m_unbroadcast_txids \n", inv.hash.GetHex());
+                }
             } else {
                 auto txinfo = mempool.info(inv.hash);
                 // To protect privacy, do not answer getdata using the mempool when

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -772,6 +772,14 @@ void PeerLogicValidation::InitializeNode(CNode *pnode) {
         PushNodeVersion(pnode, connman, GetTime());
 }
 
+void PeerLogicValidation::QueueUnbroadcastTxs(CNode* pnode)
+{
+    for(const uint256& txid : mempool.m_unbroadcast_txids){
+        CInv inv(MSG_TX, txid);
+        pnode->PushInventory(inv);
+    }
+}
+
 void PeerLogicValidation::FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTime) {
     fUpdateConnectionTime = false;
     LOCK(cs_main);

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -72,6 +72,7 @@ public:
     /** If we have extra outbound peers, try to disconnect the one with the oldest block announcement */
     void EvictExtraOutboundPeers(int64_t time_in_seconds) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+    void QueueUnbroadcastTxs(CNode* pnode) override;
 private:
     int64_t m_stale_tip_check_time; //!< Next time to check for stale tip
 };

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -11,6 +11,7 @@
 class BanMan;
 class CConnman;
 class CTxMemPool;
+class CScheduler;
 class PeerLogicValidation;
 namespace interfaces {
 class Chain;
@@ -34,6 +35,7 @@ struct NodeContext {
     std::unique_ptr<BanMan> banman;
     std::unique_ptr<interfaces::Chain> chain;
     std::vector<std::unique_ptr<interfaces::ChainClient>> chain_clients;
+    CScheduler* scheduler{nullptr};
 
     //! Declare default constructor and destructor that are not inline, so code
     //! instantiating the NodeContext struct doesn't need to #include class

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -79,6 +79,10 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
     }
 
     if (relay) {
+        // the mempool tracks locally submitted transactions to make a
+        // best-effort of initial broadcast
+        mempool.m_unbroadcast_txids.insert(hashTx);
+
         RelayTransaction(hashTx, *node.connman);
     }
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -27,6 +27,7 @@ public:
 static const CRPCConvertParam vRPCConvertParams[] =
 {
     { "setmocktime", 0, "timestamp" },
+    { "mockscheduler", 0, "delta_time" },
     { "utxoupdatepsbt", 1, "descriptors" },
     { "generatetoaddress", 0, "nblocks" },
     { "generatetoaddress", 2, "maxtries" },

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -5,15 +5,18 @@
 
 #include <httpserver.h>
 #include <key_io.h>
+#include <node/context.h>
 #include <outputtype.h>
 #include <rpc/blockchain.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
 #include <script/descriptor.h>
+#include <scheduler.h>
 #include <util/check.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <util/validation.h>
+#include <init.h>
 
 #include <stdint.h>
 #include <tuple>
@@ -366,6 +369,27 @@ static UniValue setmocktime(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
+static UniValue mockscheduler(const JSONRPCRequest& request)
+{
+        RPCHelpMan{"mockscheduler",
+            "\nBump the scheduler into the future (-regtest only)\n",
+            {
+                {"delta_time", RPCArg::Type::NUM, RPCArg::Optional::NO, "Number of seconds to forward the scheduler into the future." },
+            },
+            RPCResults{},
+            RPCExamples{""},
+        }.Check(request);
+
+    if (!Params().MineBlocksOnDemand())
+        throw std::runtime_error("mockscheduler for regression testing (-regtest mode) only");
+
+    RPCTypeCheck(request.params, {UniValue::VNUM});
+
+    g_rpc_node->scheduler->MockForward(boost::chrono::seconds(request.params[0].get_int64()));
+
+    return NullUniValue;
+}
+
 static UniValue RPCLockedMemoryInfo()
 {
     LockedPool::Stats stats = LockedPoolManager::Instance().stats();
@@ -570,6 +594,7 @@ static const CRPCCommand commands[] =
 
     /* Not shown in help */
     { "hidden",             "setmocktime",            &setmocktime,            {"timestamp"}},
+    { "hidden",             "mockscheduler",          &mockscheduler,          {"delta_time"}},
     { "hidden",             "echo",                   &echo,                   {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
     { "hidden",             "echojson",               &echo,                   {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
 };

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -114,6 +114,27 @@ void CScheduler::scheduleFromNow(CScheduler::Function f, int64_t deltaMilliSecon
     schedule(f, boost::chrono::system_clock::now() + boost::chrono::milliseconds(deltaMilliSeconds));
 }
 
+void CScheduler::MockForward(boost::chrono::seconds delta_seconds)
+{
+    {
+        boost::unique_lock<boost::mutex> lock(newTaskMutex);
+
+        // use temp_queue to maintain updated schedule
+        std::multimap<boost::chrono::system_clock::time_point, Function> temp_queue;
+
+        for (const auto& element : taskQueue){
+            boost::chrono::system_clock::time_point new_time = element.first - delta_seconds;
+            temp_queue.emplace_hint(temp_queue.cend(), new_time, element.second);
+        }
+
+        // point taskQueue to temp_queue
+        taskQueue = std::move(temp_queue);
+    }
+
+    // notify that the taskQueue needs to be processed
+    newTaskScheduled.notify_one();
+}
+
 static void Repeat(CScheduler* s, CScheduler::Function f, int64_t deltaMilliSeconds)
 {
     f();

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -55,6 +55,11 @@ public:
     // need more accurate scheduling, don't use this method.
     void scheduleEvery(Function f, int64_t deltaMilliSeconds);
 
+    // Regtest only- mock the scheduler to fast forward in time
+    // Iterates through items on taskQueue and reschedules them
+    // to be delta_seconds sooner.
+    void MockForward(boost::chrono::seconds delta_seconds);
+
     // To keep things as simple as possible, there is no unschedule.
 
     // Services the queue 'forever'. Should be run in a thread,

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -155,4 +155,46 @@ BOOST_AUTO_TEST_CASE(singlethreadedscheduler_ordered)
     BOOST_CHECK_EQUAL(counter2, 100);
 }
 
+BOOST_AUTO_TEST_CASE(mockforward)
+{
+    CScheduler scheduler;
+
+    int counter{0};
+    CScheduler::Function dummy = [&counter](){counter++;};
+
+    // schedule jobs for 2, 5 & 8 minutes into the future
+    int64_t min_in_milli = 60*1000;
+    scheduler.scheduleFromNow(dummy, 2*min_in_milli);
+    scheduler.scheduleFromNow(dummy, 5*min_in_milli);
+    scheduler.scheduleFromNow(dummy, 8*min_in_milli);
+
+    // check taskQueue
+    boost::chrono::system_clock::time_point first, last;
+    size_t num_tasks = scheduler.getQueueInfo(first, last);
+    BOOST_CHECK(num_tasks == 3);
+
+    boost::thread scheduler_thread(std::bind(&CScheduler::serviceQueue, &scheduler));
+
+    // bump the scheduler forward 5 minutes
+    scheduler.MockForward(boost::chrono::seconds(5*60));
+
+    // finish up
+    MicroSleep(600);
+    scheduler.stop(false);
+    scheduler_thread.join();
+
+    // check that the queue only has one job remaining
+    num_tasks = scheduler.getQueueInfo(first, last);
+    BOOST_CHECK_EQUAL(num_tasks, 1);
+
+    // check that the dummy function actually ran
+    BOOST_CHECK_EQUAL(counter, 2);
+
+    // check that the time of the remaining job has been updated
+    boost::chrono::system_clock::time_point now = boost::chrono::system_clock::now();
+    int delta = boost::chrono::duration_cast<boost::chrono::seconds>(first - now).count();
+    // should be between 2 & 3 minutes from now
+    BOOST_CHECK(delta > 2*60 && delta < 3*60);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -414,6 +414,10 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
     for (const CTxIn& txin : it->GetTx().vin)
         mapNextTx.erase(txin.prevout);
 
+    if (mempool.m_unbroadcast_txids.erase(hash)) {
+        LogPrint(BCLog::NET, "Removed %i from m_unbroadcast_txids before GETDATA was received. \n", hash.GetHex());
+    }
+
     if (vTxHashes.size() > 1) {
         vTxHashes[it->vTxHashesIdx] = std::move(vTxHashes.back());
         vTxHashes[it->vTxHashesIdx].second->vTxHashesIdx = it->vTxHashesIdx;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -531,6 +531,10 @@ public:
     const setEntries & GetMemPoolParents(txiter entry) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     const setEntries & GetMemPoolChildren(txiter entry) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     uint64_t CalculateDescendantMaximum(txiter entry) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+
+    // track locally submitted transactions & periodically retry initial broadcast
+    std::set<uint256> m_unbroadcast_txids;
+
 private:
     typedef std::map<txiter, setEntries, CompareIteratorByHash> cacheMap;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1973,7 +1973,7 @@ void CWallet::ResendWalletTransactions()
     // that these are our transactions.
     if (GetTime() < nNextResend || !fBroadcastTransactions) return;
     bool fFirst = (nNextResend == 0);
-    nNextResend = GetTime() + GetRand(30 * 60);
+    nNextResend = GetTime() + GetRand(24 * 60 * 60);
     if (fFirst) return;
 
     // Only do it if there's been a new block since last time

--- a/test/functional/mempool_unbroadcast.py
+++ b/test/functional/mempool_unbroadcast.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that the mempool ensures transaction delivery by periodically sending
+to peers until a GETDATA is received."""
+
+from collections import defaultdict
+from io import BytesIO
+import time
+
+from test_framework.blocktools import create_block, create_coinbase
+from test_framework.messages import ToHex, CTransaction
+from test_framework.mininode import P2PTxInvStore
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+        assert_equal,
+        disconnect_nodes,
+        connect_nodes,
+        create_confirmed_utxos,
+        wait_until,
+        hex_str_to_bytes
+)
+
+class MempoolUnbroadcastTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+
+    def run_test(self):
+        self.test_broadcast()
+        self.test_txn_removal()
+
+    def test_broadcast(self):
+        self.log.info("Test that mempool reattempts delivery of locally submitted transaction")
+        node = self.nodes[0]
+
+        min_relay_fee = node.getnetworkinfo()["relayfee"]
+        utxos = create_confirmed_utxos(min_relay_fee, node, 10)
+
+        disconnect_nodes(node, 1)
+
+        self.log.info("Generate transactions that only node 0 knows about")
+        # generate a wallet txn
+        addr = node.getnewaddress()
+        wallet_tx_hsh = node.sendtoaddress(addr, 0.0001)
+
+        # generate a txn using sendrawtransaction
+        us0 = utxos.pop()
+        inputs = [{ "txid" : us0["txid"], "vout" : us0["vout"]}]
+        outputs = {addr: 0.0001}
+        tx = node.createrawtransaction(inputs, outputs)
+        node.settxfee(min_relay_fee)
+        txF = node.fundrawtransaction(tx)
+        txFS = node.signrawtransactionwithwallet(txF['hex'])
+        rpc_tx_hsh = node.sendrawtransaction(txFS['hex'])  # txhsh in hex
+
+        # check that second node doesn't have these two txns
+        mempool = self.nodes[1].getrawmempool()
+        assert(rpc_tx_hsh not in mempool)
+        assert(wallet_tx_hsh not in mempool)
+
+        self.log.info("Reconnect nodes & check if they are sent to node 1")
+        connect_nodes(node, 1)
+
+        # fast forward into the future & ensure that the second node has the txns
+        node.mockscheduler(10*60) # 10 min in seconds
+        wait_until(lambda: len(self.nodes[1].getrawmempool()) == 2, timeout=30)
+        mempool = self.nodes[1].getrawmempool()
+        assert(rpc_tx_hsh in mempool)
+        assert(wallet_tx_hsh in mempool)
+
+        self.log.info("Add another connection & ensure transactions aren't broadcast again")
+
+        conn = node.add_p2p_connection(P2PTxInvStore())
+        node.mockscheduler(10*60)
+        time.sleep(5)
+        assert_equal(len(conn.get_invs()), 0)
+
+    def test_txn_removal(self):
+        self.log.info("Test that transactions removed from mempool are removed from unbroadcast set")
+        node = self.nodes[0]
+        disconnect_nodes(node, 1)
+
+        min_relay_fee = node.getnetworkinfo()["relayfee"]
+        utxos = create_confirmed_utxos(min_relay_fee, node, 10)
+
+        # create a transaction & submit to node
+        # since the node doesn't have any connections, it will not receive
+        # any GETDATAs & thus the transaction will remain in the unbroadcast set.
+        utxo = utxos.pop()
+        outputs = { node.getnewaddress() : 0.0001 }
+        inputs = [{'txid': utxo['txid'], 'vout': utxo['vout']}]
+        raw_tx_hex = node.createrawtransaction(inputs, outputs)
+        signed_tx = node.signrawtransactionwithwallet(raw_tx_hex)
+        txhsh = node.sendrawtransaction(hexstring=signed_tx['hex'], maxfeerate=0)
+
+        # mine a block with that transaction
+        block = create_block(int(node.getbestblockhash(), 16), create_coinbase(node.getblockcount() + 1))
+        tx = CTransaction()
+        tx.deserialize(BytesIO(hex_str_to_bytes(signed_tx['hex'])))
+        block.vtx.append(tx)
+        block.rehash()
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.solve()
+        node.submitblock(ToHex(block))
+
+        # add a connection to node
+        conn = node.add_p2p_connection(P2PTxInvStore())
+
+        # the transaction should have been removed from the unbroadcast set
+        # since it was removed from the mempool for MemPoolRemovalReason::BLOCK.
+        # verify by checking it isn't broadcast to the node's new connection.
+        time.sleep(5)
+        txid = int(txhsh, 16)
+        assert(txid not in conn.get_invs())
+
+if __name__ == '__main__':
+    MempoolUnbroadcastTest().main()
+

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -606,3 +606,19 @@ class P2PDataStore(P2PInterface):
                 # Check that none of the txs are now in the mempool
                 for tx in txs:
                     assert tx.hash not in raw_mempool, "{} tx found in mempool".format(tx.hash)
+
+class P2PTxInvStore(P2PInterface):
+    def __init__(self):
+        super().__init__()
+        self.tx_invs_received = defaultdict(int)
+
+    def on_inv(self, message):
+        # Store how many times invs have been received for each tx.
+        for i in message.inv:
+            if i.type == 1:
+                # save txid
+                self.tx_invs_received[i.hash] += 1
+
+    def get_invs(self):
+        with mininode_lock:
+            return list(self.tx_invs_received.keys())

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -204,6 +204,7 @@ BASE_SCRIPTS = [
     'p2p_dos_header_tree.py',
     'p2p_unrequested_blocks.py',
     'feature_includeconf.py',
+    'mempool_unbroadcast.py',
     'rpc_deriveaddresses.py',
     'rpc_deriveaddresses.py --usecli',
     'rpc_scantxoutset.py',

--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -66,9 +66,9 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         node.p2ps[1].sync_with_ping()
         assert_equal(node.p2ps[1].tx_invs_received[txid], 0)
 
-        self.log.info("Transaction should be rebroadcast after 30 minutes")
-        # Use mocktime and give an extra 5 minutes to be sure.
-        rebroadcast_time = int(time.time()) + 41 * 60
+        self.log.info("Transaction should be rebroadcast after 24 hours")
+        # Use mocktime and give an extra hour to be sure.
+        rebroadcast_time = int(time.time()) + 25 * 60 * 60
         node.setmocktime(rebroadcast_time)
         wait_until(lambda: node.p2ps[1].tx_invs_received[txid] >= 1, lock=mininode_lock)
 

--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -8,21 +8,9 @@ import time
 
 from test_framework.blocktools import create_block, create_coinbase
 from test_framework.messages import ToHex
-from test_framework.mininode import P2PInterface, mininode_lock
+from test_framework.mininode import P2PTxInvStore, mininode_lock
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, wait_until
-
-class P2PStoreTxInvs(P2PInterface):
-    def __init__(self):
-        super().__init__()
-        self.tx_invs_received = defaultdict(int)
-
-    def on_inv(self, message):
-        # Store how many times invs have been received for each tx.
-        for i in message.inv:
-            if i.type == 1:
-                # save txid
-                self.tx_invs_received[i.hash] += 1
 
 class ResendWalletTransactionsTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -34,7 +22,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
     def run_test(self):
         node = self.nodes[0]  # alias
 
-        node.add_p2p_connection(P2PStoreTxInvs())
+        node.add_p2p_connection(P2PTxInvStore())
 
         self.log.info("Create a new transaction and wait until it's broadcast")
         txid = int(node.sendtoaddress(node.getnewaddress(), 1), 16)
@@ -49,7 +37,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         wait_until(lambda: node.p2p.tx_invs_received[txid] >= 1, lock=mininode_lock)
 
         # Add a second peer since txs aren't rebroadcast to the same peer (see filterInventoryKnown)
-        node.add_p2p_connection(P2PStoreTxInvs())
+        node.add_p2p_connection(P2PTxInvStore())
 
         self.log.info("Create a block")
         # Create and submit a block without the transaction.


### PR DESCRIPTION
Mirror of bitcoin bitcoin#18038
This piece of functionality has been extracted #16698 as a standalone change. It builds on #18037, please review that PR first 🙏🏽

The current rebroadcast logic is terrible for privacy because 1. only the source wallet rebroadcasts transactions and 2. it does so quite frequently. In the current system, if a user submits a transaction that does not immediately get broadcast to the network (eg. they are offline), this "rebroadcast" behavior is the safety net that can actually serve as the initial broadcast. So, keeping the attempts frequent is important for initial delivery within a reasonable timespan. 

This PR aims to improve # 2 by separating the notion of initial broadcast from rebroadcasts. With these changes, the mempool tracks locally submitted transactions & periodically reattempts initial broadcast. Transactions submitted via the wallet or RPC are added to an "unbroadcast" set & are removed when a peer sends a `getdata` request, or the transaction is removed from the mempool. Every 10 minutes, the node reattempts an initial broadcast. This allows reducing the wallet rebroadcast frequency to ~1/day from ~1/30 min, while still ensuring the transactions will be propagated to the network. 

For privacy improvements around # 1, please see #16698. 
