### PR TITLE
Mirror of bitcoin bitcoin#18037

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1272,6 +1272,9 @@ bool AppInitMain(NodeContext& node)
     CScheduler::Function serviceLoop = std::bind(&CScheduler::serviceQueue, &scheduler);
     threadGroup.create_thread(std::bind(&TraceThread<CScheduler::Function>, "scheduler", serviceLoop));
 
+    assert(!node.scheduler);
+    node.scheduler = &scheduler;
+
     // Gather some entropy once per minute.
     scheduler.scheduleEvery([]{
         RandAddPeriodic();

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -11,6 +11,7 @@
 class BanMan;
 class CConnman;
 class CTxMemPool;
+class CScheduler;
 class PeerLogicValidation;
 namespace interfaces {
 class Chain;
@@ -34,6 +35,7 @@ struct NodeContext {
     std::unique_ptr<BanMan> banman;
     std::unique_ptr<interfaces::Chain> chain;
     std::vector<std::unique_ptr<interfaces::ChainClient>> chain_clients;
+    CScheduler* scheduler{nullptr};
 
     //! Declare default constructor and destructor that are not inline, so code
     //! instantiating the NodeContext struct doesn't need to #include class

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -27,6 +27,7 @@ public:
 static const CRPCConvertParam vRPCConvertParams[] =
 {
     { "setmocktime", 0, "timestamp" },
+    { "mockscheduler", 0, "delta_time" },
     { "utxoupdatepsbt", 1, "descriptors" },
     { "generatetoaddress", 0, "nblocks" },
     { "generatetoaddress", 2, "maxtries" },

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -5,15 +5,18 @@
 
 #include <httpserver.h>
 #include <key_io.h>
+#include <node/context.h>
 #include <outputtype.h>
 #include <rpc/blockchain.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
 #include <script/descriptor.h>
+#include <scheduler.h>
 #include <util/check.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <util/validation.h>
+#include <init.h>
 
 #include <stdint.h>
 #include <tuple>
@@ -366,6 +369,27 @@ static UniValue setmocktime(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
+static UniValue mockscheduler(const JSONRPCRequest& request)
+{
+        RPCHelpMan{"mockscheduler",
+            "\nBump the scheduler into the future (-regtest only)\n",
+            {
+                {"delta_time", RPCArg::Type::NUM, RPCArg::Optional::NO, "Number of seconds to forward the scheduler into the future." },
+            },
+            RPCResults{},
+            RPCExamples{""},
+        }.Check(request);
+
+    if (!Params().MineBlocksOnDemand())
+        throw std::runtime_error("mockscheduler for regression testing (-regtest mode) only");
+
+    RPCTypeCheck(request.params, {UniValue::VNUM});
+
+    g_rpc_node->scheduler->MockForward(boost::chrono::seconds(request.params[0].get_int64()));
+
+    return NullUniValue;
+}
+
 static UniValue RPCLockedMemoryInfo()
 {
     LockedPool::Stats stats = LockedPoolManager::Instance().stats();
@@ -570,6 +594,7 @@ static const CRPCCommand commands[] =
 
     /* Not shown in help */
     { "hidden",             "setmocktime",            &setmocktime,            {"timestamp"}},
+    { "hidden",             "mockscheduler",          &mockscheduler,          {"delta_time"}},
     { "hidden",             "echo",                   &echo,                   {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
     { "hidden",             "echojson",               &echo,                   {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
 };

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -114,6 +114,27 @@ void CScheduler::scheduleFromNow(CScheduler::Function f, int64_t deltaMilliSecon
     schedule(f, boost::chrono::system_clock::now() + boost::chrono::milliseconds(deltaMilliSeconds));
 }
 
+void CScheduler::MockForward(boost::chrono::seconds delta_seconds)
+{
+    {
+        boost::unique_lock<boost::mutex> lock(newTaskMutex);
+
+        // use temp_queue to maintain updated schedule
+        std::multimap<boost::chrono::system_clock::time_point, Function> temp_queue;
+
+        for (const auto& element : taskQueue){
+            boost::chrono::system_clock::time_point new_time = element.first - delta_seconds;
+            temp_queue.emplace_hint(temp_queue.cend(), new_time, element.second);
+        }
+
+        // point taskQueue to temp_queue
+        taskQueue = std::move(temp_queue);
+    }
+
+    // notify that the taskQueue needs to be processed
+    newTaskScheduled.notify_one();
+}
+
 static void Repeat(CScheduler* s, CScheduler::Function f, int64_t deltaMilliSeconds)
 {
     f();

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -55,6 +55,11 @@ public:
     // need more accurate scheduling, don't use this method.
     void scheduleEvery(Function f, int64_t deltaMilliSeconds);
 
+    // Regtest only- mock the scheduler to fast forward in time
+    // Iterates through items on taskQueue and reschedules them
+    // to be delta_seconds sooner.
+    void MockForward(boost::chrono::seconds delta_seconds);
+
     // To keep things as simple as possible, there is no unschedule.
 
     // Services the queue 'forever'. Should be run in a thread,

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -155,4 +155,46 @@ BOOST_AUTO_TEST_CASE(singlethreadedscheduler_ordered)
     BOOST_CHECK_EQUAL(counter2, 100);
 }
 
+BOOST_AUTO_TEST_CASE(mockforward)
+{
+    CScheduler scheduler;
+
+    int counter{0};
+    CScheduler::Function dummy = [&counter](){counter++;};
+
+    // schedule jobs for 2, 5 & 8 minutes into the future
+    int64_t min_in_milli = 60*1000;
+    scheduler.scheduleFromNow(dummy, 2*min_in_milli);
+    scheduler.scheduleFromNow(dummy, 5*min_in_milli);
+    scheduler.scheduleFromNow(dummy, 8*min_in_milli);
+
+    // check taskQueue
+    boost::chrono::system_clock::time_point first, last;
+    size_t num_tasks = scheduler.getQueueInfo(first, last);
+    BOOST_CHECK(num_tasks == 3);
+
+    boost::thread scheduler_thread(std::bind(&CScheduler::serviceQueue, &scheduler));
+
+    // bump the scheduler forward 5 minutes
+    scheduler.MockForward(boost::chrono::seconds(5*60));
+
+    // finish up
+    MicroSleep(600);
+    scheduler.stop(false);
+    scheduler_thread.join();
+
+    // check that the queue only has one job remaining
+    num_tasks = scheduler.getQueueInfo(first, last);
+    BOOST_CHECK_EQUAL(num_tasks, 1);
+
+    // check that the dummy function actually ran
+    BOOST_CHECK_EQUAL(counter, 2);
+
+    // check that the time of the remaining job has been updated
+    boost::chrono::system_clock::time_point now = boost::chrono::system_clock::now();
+    int delta = boost::chrono::duration_cast<boost::chrono::seconds>(first - now).count();
+    // should be between 2 & 3 minutes from now
+    BOOST_CHECK(delta > 2*60 && delta < 3*60);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Mirror of bitcoin bitcoin#18037
This PR is to support functional tests by allowing the scheduler to be mocked via the RPC. 

It adds a `MockForward` method to the scheduler class that iterates through the task queue and reschedules them to be `delta_seconds` sooner. 

This is currently used to support functional testing of the "unbroadcast" set tracking in #18038. If this patch is accepted, it would also be useful to simplify the code in #16698.
